### PR TITLE
Arrows location, histogram tooltip

### DIFF
--- a/smaps/src/main/webapp/css/style.css
+++ b/smaps/src/main/webapp/css/style.css
@@ -104,8 +104,14 @@ a.btn.btn-blue.active {
     margin-bottom: 1em;
 }
 
-.up-down-btn {
-    margin-right: 2.5em;
+.up-btn {
+    margin-top: 1em;
+    margin-bottom: 0.8em;
+    font-size: 1.5em;
+}
+
+.down-btn {
+    margin-bottom: 1em;
     font-size: 1.5em;
 }
 
@@ -171,12 +177,12 @@ a.btn.btn-blue.active {
 
 /* Memory Map */
 div.sticky-map-key {
+    padding-top: 2em;
     position: sticky;
     top: 0;
 }
 
 .mini-title {
-    padding-top: 2em;
     font-size: 1em;
 }
 

--- a/smaps/src/main/webapp/js/histogram.js
+++ b/smaps/src/main/webapp/js/histogram.js
@@ -91,7 +91,8 @@ function drawHistogramCust() {
           colors: ['#4285F4'],
           legend: {position: 'none'},
           hAxis: {title: 'Size in KiB'},
-          vAxis: {title: 'Number of Regions'}
+          vAxis: {title: 'Number of Regions'},
+          tooltip: {trigger: 'both'}
         };
 
         // Sets the settings for the histogram.

--- a/smaps/src/main/webapp/memory-map.html
+++ b/smaps/src/main/webapp/memory-map.html
@@ -61,8 +61,10 @@ limitations under the License.
                     <canvas id="key-canvas">Your browser does not support the HTML5 canvas tag.</canvas>
                 </div>
                 <div class="row">
-                    <a href="#top" class="btn btn-gray up-down-btn">&#8593</a>
-                    <a href="#bottom" class="btn btn-gray up-down-btn">&#8595</a>
+                    <a href="#top" class="btn btn-gray up-btn">&#8593</a>
+                </div>
+                <div class="row">
+                    <a href="#bottom" class="btn btn-gray down-btn">&#8595</a>
                 </div>
                 <div class="row">
                     <div class="mini-title">HEX ADDRESS SEARCH</div>


### PR DESCRIPTION
Changed arrow navigation buttons location on memory map page, made tooltip for histogram stay on click, so that users can copy the address and paste it into the memory map address search.
![Screenshot 2020-07-17 at 10 46 35 AM](https://user-images.githubusercontent.com/28927964/87805617-3a89c100-c81b-11ea-9bab-0fea3f16c80d.png)
