### PR TITLE
Added more defenses to file parser.

### DIFF
--- a/smaps/pom.xml
+++ b/smaps/pom.xml
@@ -117,8 +117,8 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>3.2.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/smaps/src/main/java/com/google/smaps/Analyzer.java
+++ b/smaps/src/main/java/com/google/smaps/Analyzer.java
@@ -22,6 +22,7 @@ import com.google.common.collect.TreeRangeMap;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import javax.servlet.http.HttpSession;
 
 /**
  * Takes in the data from the smaps file upload, analyzes it, and converts it into useful
@@ -30,8 +31,8 @@ import java.util.List;
 class Analyzer {
   /* Creates the list of regions from the file path using the parseRegionList method in the
    * FileParser class. */
-  static List<Region> makeRegionList(String filePathname) {
-    return FileParser.parseRegionList(filePathname);
+  static List<Region> makeRegionList(String filePathname, HttpSession session) {
+    return FileParser.parseRegionList(filePathname, session);
   }
 
   /* Creates the address range map (interval map) with addresses as keys and the region in which it

--- a/smaps/src/main/java/com/google/smaps/FileParser.java
+++ b/smaps/src/main/java/com/google/smaps/FileParser.java
@@ -69,11 +69,13 @@ class FileParser {
       if (checkNewRegion(line)) {
         // Build the previous region (if there is one) and add it to the list.
         if (prevRegion) {
-          // Ensure that a valid size was set for this region.
+          // Build region and add it to the list if it has a valid size field, if not throw an
+          // IllegalArgumentException.
           Region r = region.build();
           if (r.size() == -1) {
             session.setAttribute("fileErrorMessage",
-                "One or more regions does not contain a 'size' field, see go/smaps-vis/smaps-example.txt to view properly formatted smaps file.");
+                "Required 'size' field not found in region on line [" + r.lineNumber()
+                    + "] in smaps file.");
             throw new IllegalArgumentException();
           }
           regions.add(r);
@@ -93,7 +95,8 @@ class FileParser {
 
         if (attributes.length < 5) {
           session.setAttribute("fileErrorMessage",
-              "One or more regions does not have first line properly formatted, see go/smaps-vis/smaps-example.txt to view properly formatted smaps file.");
+              "Region on line [" + lineNumber
+                  + "] does not have proper first line formatting. EX: 7fd126400000-7fd12a400000 rw-s 00000000 00:05 30559");
           throw new IllegalArgumentException();
         }
 
@@ -156,8 +159,14 @@ class FileParser {
       }
     }
 
-    // Build the final region.
+    // Build the final region and add it to the list if it contains a valid size field.
     Region r = region.build();
+    if (r.size() == -1) {
+      session.setAttribute("fileErrorMessage",
+          "Required 'size' field not found in region on line [" + r.lineNumber()
+              + "] in smaps file.");
+      throw new IllegalArgumentException();
+    }
     regions.add(r);
 
     // Close the scanner and return the list.

--- a/smaps/src/main/java/com/google/smaps/FileParser.java
+++ b/smaps/src/main/java/com/google/smaps/FileParser.java
@@ -93,7 +93,7 @@ class FileParser {
 
         if (attributes.length < 5) {
           session.setAttribute("fileErrorMessage",
-              "First line for each region not formatted properly, see go/smaps-vis/smaps-example.txt to view properly formatted smaps file.");
+              "One or more regions does not have first line properly formatted, see go/smaps-vis/smaps-example.txt to view properly formatted smaps file.");
           throw new IllegalArgumentException();
         }
 

--- a/smaps/src/main/java/com/google/smaps/FileParser.java
+++ b/smaps/src/main/java/com/google/smaps/FileParser.java
@@ -35,18 +35,28 @@ class FileParser {
       List<Region> regions = parseFile(filePathname, session);
       return regions;
     } catch (FileNotFoundException e) {
+      // Set a file not found error.
       session.setAttribute("fileErrorMessage", "File not found.");
-      System.out.println("File not found.");
     } catch (IllegalArgumentException e) {
-      System.out.println("File has improper formatting.");
+      // If a more specific fileErrorMessage wasn't already set, set a general one.
+      String message = (String) session.getAttribute("fileErrorMessage");
+      if (message == null || message.isEmpty()) {
+        session.setAttribute("fileErrorMessage",
+            "File was unable to be parsed due to improper formatting or file type.");
+      }
+    } catch (Exception e) {
+      // Set a general error.
+      session.setAttribute("fileErrorMessage",
+          "File was unable to be parsed due to improper formatting or file type.");
     }
+
     // If an exception was caught, return null.
     return null;
   }
 
   /* Parses the smaps file and returns a list of regions.*/
   static List<Region> parseFile(String filePathname, HttpSession session)
-      throws FileNotFoundException, IllegalArgumentException {
+      throws FileNotFoundException, IllegalArgumentException, IllegalStateException {
     // Holds all regions of smaps dump.
     List<Region> regions = new ArrayList<Region>();
     // Create the file.

--- a/smaps/src/main/java/com/google/smaps/FileUpload.java
+++ b/smaps/src/main/java/com/google/smaps/FileUpload.java
@@ -80,7 +80,7 @@ public class FileUpload extends HttpServlet {
     // Check if the file part is empty (meaning no file was selected or the file was empty).
     if (filePart.getSize() == 0) {
       // Set the error message.
-      fileErrorMessage = "Error: No file chosen or file was empty.";
+      fileErrorMessage = "No file chosen or file was empty.";
       session.setAttribute("fileErrorMessage", fileErrorMessage);
       // Send user back to the index.html page with error message printed with doGet.
       response.sendRedirect("/index.html");

--- a/smaps/src/main/java/com/google/smaps/FileUpload.java
+++ b/smaps/src/main/java/com/google/smaps/FileUpload.java
@@ -145,7 +145,8 @@ public class FileUpload extends HttpServlet {
     // Check if there were any issues with file upload. If there were, fileErrorMessage in the
     // session would have been set, so return to index. If not, set the region list to the session
     // and continue.
-    if (!(((String) session.getAttribute("fileErrorMessage")).equals(""))) {
+    String message = (String) session.getAttribute("fileErrorMessage");
+    if (!message.isEmpty()) {
       // Immediately return null, so that the file with upload issues will not continue to be
       // parsed.
       return null;

--- a/smaps/src/main/java/com/google/smaps/FileUpload.java
+++ b/smaps/src/main/java/com/google/smaps/FileUpload.java
@@ -90,8 +90,16 @@ public class FileUpload extends HttpServlet {
     // Create an input stream from the file the user uploaded.
     InputStream fileInputStream = filePart.getInputStream();
 
-    // Get the randomized filename from uploadFile and set the filename to the session.
+    // Get the randomized filename from uploadFile.
     filename = uploadFile(session, fileInputStream);
+
+    // If filename is null, there was an error with parsing, so return to homepage.
+    if (filename == null) {
+      response.sendRedirect("/index.html");
+      return;
+    }
+
+    // Set the filename to the session.
     session.setAttribute("filename", filename);
 
     // Send user to the histogram page.
@@ -132,8 +140,18 @@ public class FileUpload extends HttpServlet {
 
     // Make the list of regions from this file that will be utilized for various
     // charts/visualizations, and set the list to the session.
-    List<Region> regionList = Analyzer.makeRegionList(filename);
-    session.setAttribute("regionList", regionList);
+    List<Region> regionList = Analyzer.makeRegionList(filename, session);
+
+    // Check if there were any issues with file upload. If there were, fileErrorMessage in the
+    // session would have been set, so return to index. If not, set the region list to the session
+    // and continue.
+    if (!(((String) session.getAttribute("fileErrorMessage")).equals(""))) {
+      // Immediately return null, so that the file with upload issues will not continue to be
+      // parsed.
+      return null;
+    } else {
+      session.setAttribute("regionList", regionList);
+    }
 
     // Make the range map that will allow for the address search feature on the memory map page, and
     // set the range map to the session.

--- a/smaps/src/main/java/com/google/smaps/Region.java
+++ b/smaps/src/main/java/com/google/smaps/Region.java
@@ -94,8 +94,9 @@ abstract class Region implements Serializable {
   // Initializes all fields such that if they are not included in an smaps file, the app can
   // still function properly. This does not include any of the fields in the first line of a region
   // (startLoc, endLoc, permissions, offset, device, inode), because an error will occur
-  // if the file doesn't contain those fields. Size is set to -1, so that each region can be
-  // checked to ensure a valid size has been set, otherwise another error will occur.
+  // if the file doesn't contain those fields.
+  // Size is set to -1, so that each region can be checked to ensure a valid size has been set,
+  // otherwise another error will occur.
   static Builder builder() {
     return new AutoValue_Region.Builder()
         .setPathname("")

--- a/smaps/src/main/java/com/google/smaps/Region.java
+++ b/smaps/src/main/java/com/google/smaps/Region.java
@@ -17,6 +17,7 @@ package com.google.smaps;
 
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Represents a region of memory from the dump. */
@@ -90,9 +91,36 @@ abstract class Region implements Serializable {
   // share a variety of details about a memory segment.
   abstract List<String> vmFlags();
 
+  // Initializes all fields such that if they are not included in an smaps file, the app can
+  // still function properly. This does not include any of the fields in the first line of a region
+  // (startLoc, endLoc, permissions, offset, device, inode), because an error will occur
+  // if the file doesn't contain those fields. Size is set to -1, so that each region can be
+  // checked to ensure a valid size has been set, otherwise another error will occur.
   static Builder builder() {
-    // TODO(sophbohr22): Add these set initializations for all fields.
-    return new AutoValue_Region.Builder().setShmemHugePages(0).setHugePFNMap(0);
+    return new AutoValue_Region.Builder()
+        .setPathname("")
+        .setSize(-1)
+        .setKernelPageSize(0)
+        .setMmuPageSize(0)
+        .setRss(0)
+        .setPss(0)
+        .setSharedClean(0)
+        .setSharedDirty(0)
+        .setPrivateClean(0)
+        .setPrivateDirty(0)
+        .setReferenced(0)
+        .setAnonymous(0)
+        .setLazyFree(0)
+        .setAnonHugePages(0)
+        .setShmemHugePages(0)
+        .setShmemPmdMapped(0)
+        .setSharedHugetlb(0)
+        .setPrivateHugetlb(0)
+        .setHugePFNMap(0)
+        .setSwap(0)
+        .setSwapPss(0)
+        .setLocked(0)
+        .setVmFlags(new ArrayList<String>());
   }
 
   @AutoValue.Builder

--- a/smaps/src/test/java/com/google/smaps/AnalyzerTest.java
+++ b/smaps/src/test/java/com/google/smaps/AnalyzerTest.java
@@ -16,10 +16,12 @@
 package com.google.smaps;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableRangeMap;
 import java.math.BigInteger;
 import java.util.List;
+import javax.servlet.http.HttpSession;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,18 +32,21 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class AnalyzerTest {
-  List<Region> regionList;
+  private List<Region> regionList;
+  private HttpSession session;
 
   @Before
   public void createRegionList() {
+    // Creates a session.
+    session = mock(HttpSession.class);
     // Creates the regions list from smaps-full.txt file.
-    regionList = Analyzer.makeRegionList("../smaps-full.txt");
+    regionList = Analyzer.makeRegionList("../smaps-full.txt", session);
   }
 
   @Test
   public void retrieveRegionList() {
     // Tests that the list Analyzer is returning is the same list that is created in FileParser.
-    List<Region> regions = FileParser.parseRegionList("../smaps-full.txt");
+    List<Region> regions = FileParser.parseRegionList("../smaps-full.txt", session);
     assertEquals(regions, regionList);
   }
 

--- a/smaps/src/test/java/com/google/smaps/FileParserTest.java
+++ b/smaps/src/test/java/com/google/smaps/FileParserTest.java
@@ -16,11 +16,13 @@
 package com.google.smaps;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.servlet.http.HttpSession;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,17 +34,20 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FileParserTest {
   private List<Region> regions;
+  private HttpSession session;
 
   @Before
   public void createRegionList() throws Exception {
+    // Creates a session.
+    session = mock(HttpSession.class);
     // Creates regions list from smaps-full.txt file.
-    regions = Analyzer.makeRegionList("../smaps-full.txt");
+    regions = Analyzer.makeRegionList("../smaps-full.txt", session);
   }
 
   @Test
   public void fileNotFound() {
     // Tests that an empty list is successfully returned with nonexistent file.
-    List<Region> list = Analyzer.makeRegionList("../fake-file.txt");
+    List<Region> list = Analyzer.makeRegionList("../fake-file.txt", session);
     assertNull(list);
   }
 
@@ -50,7 +55,7 @@ public class FileParserTest {
   public void wrongFileFormat() {
     // Tests that an empty list is successfully returned with a file that has too few parameters on
     // first line.
-    List<Region> list = Analyzer.makeRegionList("../smaps-wrong-format.txt");
+    List<Region> list = Analyzer.makeRegionList("../smaps-wrong-format.txt", session);
     assertNull(list);
   }
 

--- a/smaps/src/test/java/com/google/smaps/HistogramTest.java
+++ b/smaps/src/test/java/com/google/smaps/HistogramTest.java
@@ -17,7 +17,7 @@ package com.google.smaps;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.io.PrintWriter;
@@ -25,6 +25,7 @@ import java.io.StringWriter;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +46,7 @@ public class HistogramTest {
   @Mock private HttpServletResponse mockResponse;
   private StringWriter responseWriter;
   private Histogram servletUnderTest;
+  private HttpSession session;
 
   @Before
   public void setUp() throws Exception {
@@ -59,7 +61,11 @@ public class HistogramTest {
     responseWriter = new StringWriter();
     when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
 
+    // Creates Histogram servlet.
     servletUnderTest = new Histogram();
+
+    // Creates a session.
+    session = mock(HttpSession.class);
   }
 
   @After
@@ -73,7 +79,7 @@ public class HistogramTest {
   @Test
   public void dataArray() {
     // Tests creation of list of Object arrays for histogram from regions list.
-    List<Region> regions = Analyzer.makeRegionList("../smaps-full.txt");
+    List<Region> regions = Analyzer.makeRegionList("../smaps-full.txt", session);
     List<Object[]> dataArray = servletUnderTest.makeDataArray(regions);
 
     // Checks labels.

--- a/smaps/src/test/java/com/google/smaps/MemoryMapTest.java
+++ b/smaps/src/test/java/com/google/smaps/MemoryMapTest.java
@@ -17,7 +17,7 @@ package com.google.smaps;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.io.PrintWriter;
@@ -25,6 +25,7 @@ import java.io.StringWriter;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +46,7 @@ public class MemoryMapTest {
   @Mock private HttpServletResponse mockResponse;
   private StringWriter responseWriter;
   private MemoryMap servletUnderTest;
+  private HttpSession session;
 
   @Before
   public void setUp() throws Exception {
@@ -59,7 +61,11 @@ public class MemoryMapTest {
     responseWriter = new StringWriter();
     when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
 
+    // Creates MemoryMap servlet.
     servletUnderTest = new MemoryMap();
+
+    // Creates a session.
+    session = mock(HttpSession.class);
   }
 
   @After
@@ -73,7 +79,7 @@ public class MemoryMapTest {
   @Test
   public void dataArray() {
     // Tests creation of list of Object arrays for histogram from regions list.
-    List<Region> regions = Analyzer.makeRegionList("../smaps-full.txt");
+    List<Region> regions = Analyzer.makeRegionList("../smaps-full.txt", session);
     List<Object[]> dataArray = servletUnderTest.makeDataArray(regions);
 
     // Checks first entry.

--- a/smaps/src/test/java/com/google/smaps/SearchAddressTest.java
+++ b/smaps/src/test/java/com/google/smaps/SearchAddressTest.java
@@ -17,7 +17,7 @@ package com.google.smaps;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.common.collect.ImmutableRangeMap;
@@ -71,8 +71,11 @@ public class SearchAddressTest {
     // Create an instance of the SearchAddress servlet.
     servletUnderTest = new SearchAddress();
 
+    // Creates a session.
+    session = mock(HttpSession.class);
+
     // Make the regions list and range map.
-    regions = Analyzer.makeRegionList("../smaps-full.txt");
+    regions = Analyzer.makeRegionList("../smaps-full.txt", session);
     addressRangeMap = Analyzer.makeRangeMap(regions);
   }
 


### PR DESCRIPTION
- Added initializations to all fields in Region.java except for the fields in the first line of an smaps file (ex: 7fd148680000-7fd148688000 ---p 00000000 00:00 0). If any of these fields are missing, the following error message is printed to the homepage:
![Screenshot 2020-08-10 at 1 29 48 PM](https://user-images.githubusercontent.com/28927964/89817517-e61dec80-db0d-11ea-9a46-914e346c0df6.png)

- Initialized the 'size' field in Region.java to -1, so that if at any point in file upload there's a region without a size field, the file parser returns and the following error message is printed to the homepage:
![Screenshot 2020-08-10 at 1 30 05 PM](https://user-images.githubusercontent.com/28927964/89817934-8d9b1f00-db0e-11ea-893c-7def382bc847.png)

- Since all other fields are not necessary for proper function of the histogram and memory map, they can be safely initialized to 0 or "", and if they're never set to anything in the parser then they'll just stay at 0 or "".
